### PR TITLE
Fix mousewheel support for RStudio and old browsers

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -46,11 +46,13 @@ export default function() {
       touchstarting,
       touchending,
       touchDelay = 500,
-      wheelDelay = 150;
+      wheelDelay = 150,
+      // Test for wheel event ype
+      wheelSupport = document.onmousewheel !== undefined ? "mousewheel" : "wheel";
 
   function zoom(selection) {
     selection
-        .on("wheel.zoom", wheeled)
+        .on(wheelSupport + ".zoom", wheeled)
         .on("mousedown.zoom", mousedowned)
         .on("dblclick.zoom", dblclicked)
         .on("touchstart.zoom", touchstarted)
@@ -200,7 +202,8 @@ export default function() {
     if (!filter.apply(this, arguments)) return;
     var g = gesture(this, arguments),
         t = this.__zoom,
-        k = Math.max(k0, Math.min(k1, t.k * Math.pow(2, -event.deltaY * (event.deltaMode ? 120 : 1) / 500))),
+	deltaY = wheelSupport == "wheel" ? -event.deltaY : event.wheelDeltaY,
+        k = Math.max(k0, Math.min(k1, t.k * Math.pow(2, deltaY * (event.deltaMode ? 120 : 1) / 500))),
         p = mouse(this);
 
     // If the mouse is in the same location as before, reuse it.


### PR DESCRIPTION
Working on a d3v4 R HTML widget, I noticed that mouse wheel events were not recognized anymore inside RStudio internal browser, whereas they are working well in Chrome or other recent external browser.

After a bit of digging it seems that RStudio doesn't support the new `wheel` event type, but still uses the old `mousewheel` one.

This pull request adds detection of the type of supported mouse wheel  event (code is from [Mozilla Developer Network `wheel` page](https://developer.mozilla.org/en-US/docs/Web/Events/wheel#Listening_to_this_event_across_browser)). It then binds the `wheeled` function to the correct event type.

The code also modifies the `deltaY` event calculation, as with `mousewheel` event the value is bound to the `wheelDeltaY` property, and its sign is reversed.

Thanks a lot,

Julien Barnier
