### PR TITLE
Fix for phantom moves

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -46,7 +46,8 @@ export default function() {
       touchstarting,
       touchending,
       touchDelay = 500,
-      wheelDelay = 150;
+      wheelDelay = 150,
+      clickDistance2 = 0;
 
   function zoom(selection) {
     selection
@@ -234,9 +235,11 @@ export default function() {
 
   function mousedowned() {
     if (touchending || !filter.apply(this, arguments)) return;
-    var g = gesture(this, arguments),
-        v = select(event.view).on("mousemove.zoom", mousemoved, true).on("mouseup.zoom", mouseupped, true),
-        p = mouse(this);
+    var g  = gesture(this, arguments),
+        v  = select(event.view).on("mousemove.zoom", mousemoved, true).on("mouseup.zoom", mouseupped, true),
+        p  = mouse(this),
+        x0 = event.clientX,
+        y0 = event.clientY;
 
     dragDisable(event.view);
     nopropagation();
@@ -246,14 +249,8 @@ export default function() {
 
     function mousemoved() {
       noevent();
-      var m = mouse(g.that);
-      if (m[0] == g.mouse[0][0] && m[1] == g.mouse[0][1]) {
-        // Mouse hasn't actually moved, so should not mark the gesture
-        // as having moved.
-        return;
-      }
-      g.moved = true;
-      g.zoom("mouse", constrain(translate(g.that.__zoom, g.mouse[0] = m, g.mouse[1]), g.extent));
+      g.moved = g.moved || Math.pow(event.clientX - x0, 2) + Math.pow(event.clientY - y0, 2) > clickDistance2;
+      g.zoom("mouse", constrain(translate(g.that.__zoom, g.mouse[0] = mouse(g.that), g.mouse[1]), g.extent));
     }
 
     function mouseupped() {
@@ -384,5 +381,9 @@ export default function() {
     return value === listeners ? zoom : value;
   };
 
+  zoom.clickDistance = function(_) {
+    return arguments.length ? (clickDistance2 = Math.pow(+_, 2), zoom) : Math.pow(clickDistance2, 0.5);
+  };
+    
   return zoom;
 }

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -235,9 +235,9 @@ export default function() {
 
   function mousedowned() {
     if (touchending || !filter.apply(this, arguments)) return;
-    var g  = gesture(this, arguments),
-        v  = select(event.view).on("mousemove.zoom", mousemoved, true).on("mouseup.zoom", mouseupped, true),
-        p  = mouse(this),
+    var g = gesture(this, arguments),
+        v = select(event.view).on("mousemove.zoom", mousemoved, true).on("mouseup.zoom", mouseupped, true),
+        p = mouse(this),
         x0 = event.clientX,
         y0 = event.clientY;
 
@@ -249,7 +249,8 @@ export default function() {
 
     function mousemoved() {
       noevent();
-      g.moved = g.moved || Math.pow(event.clientX - x0, 2) + Math.pow(event.clientY - y0, 2) > clickDistance2;
+      var dx = event.clientX - x0, dy = event.clientY - y0;
+      g.moved = g.moved || dx * dx + dy * dy > clickDistance2;
       g.zoom("mouse", constrain(translate(g.that.__zoom, g.mouse[0] = mouse(g.that), g.mouse[1]), g.extent));
     }
 
@@ -382,7 +383,7 @@ export default function() {
   };
 
   zoom.clickDistance = function(_) {
-    return arguments.length ? (clickDistance2 = Math.pow(+_, 2), zoom) : Math.pow(clickDistance2, 0.5);
+    return arguments.length ? (clickDistance2 = (_ = +_) * _, zoom) : Math.sqrt(clickDistance2);
   };
     
   return zoom;

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -246,8 +246,14 @@ export default function() {
 
     function mousemoved() {
       noevent();
+      var m = mouse(g.that);
+      if (m[0] == g.mouse[0][0] && m[1] == g.mouse[0][1]) {
+        // Mouse hasn't actually moved, so should not mark the gesture
+        // as having moved.
+        return;
+      }
       g.moved = true;
-      g.zoom("mouse", constrain(translate(g.that.__zoom, g.mouse[0] = mouse(g.that), g.mouse[1]), g.extent));
+      g.zoom("mouse", constrain(translate(g.that.__zoom, g.mouse[0] = m, g.mouse[1]), g.extent));
     }
 
     function mouseupped() {

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -249,8 +249,10 @@ export default function() {
 
     function mousemoved() {
       noevent();
-      var dx = event.clientX - x0, dy = event.clientY - y0;
-      g.moved = g.moved || dx * dx + dy * dy > clickDistance2;
+      if (!g.moved) {
+        var dx = event.clientX - x0, dy = event.clientY - y0;
+        g.moved = dx * dx + dy * dy > clickDistance2;
+      }
       g.zoom("mouse", constrain(translate(g.that.__zoom, g.mouse[0] = mouse(g.that), g.mouse[1]), g.extent));
     }
 


### PR DESCRIPTION
Sometimes (this seems to be a problem with webkit/Safari and magic mice, but has been observed on other platforms as well), a mousemove event is generated before the mouse actually moves.  This prevents a click gesture from being recognized upon a subsequent mouseup event.  The upshot is that clicking can be very difficult with most clicks just doing nothing.

This small patch checks that the mouse has indeed moved before setting the moved flag for the gesture or performing a transform.