### PR TITLE
Made constrain about viewport center (experiment!)

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -139,13 +139,15 @@ export default function() {
   }
 
   function constrain(transform, extent) {
-    var dx0 = transform.invertX(extent[0][0]) - x0,
-        dx1 = transform.invertX(extent[1][0]) - x1,
-        dy0 = transform.invertY(extent[0][1]) - y0,
-        dy1 = transform.invertY(extent[1][1]) - y1;
+    var cx = transform.invertX((extent[1][0] - extent[0][0]) / 2),
+        cy = transform.invertY((extent[1][1] - extent[0][1]) / 2);
+        dcx0 = Math.min(0, cx - x0),
+        dcx1 = Math.max(0, cx - x1),
+        dcy0 = Math.min(0, cy - y0),
+        dcy1 = Math.max(0, cy - y1);
     return transform.translate(
-      dx1 > dx0 ? (dx0 + dx1) / 2 : Math.min(0, dx0) || Math.max(0, dx1),
-      dy1 > dy0 ? (dy0 + dy1) / 2 : Math.min(0, dy0) || Math.max(0, dy1)
+      Math.min(0, dcx0) || Math.max(0, dcx1),
+      Math.min(0, dcy0) || Math.max(0, dcy1)
     );
   }
 


### PR DESCRIPTION
Not really a serious PR but more of food for thought (please feel free to close it).

My fork here is the result of an experiment of my project where users can do remote collaborative work with visualizations in real-time.

In this project it is possible to share views but because the viewports of users can differ a lot I decided to make everything about the view center, e.g. the coordinates shared are the values of the SVG transform in the current view center (subtracting half of map width/height). Also when resizing the viewport the centered content stays centered.

This fork here is then about making the constrains also all about the center, so that e.g. `.translateExtent()` only restricts panning insofar as to make sure that the center of the view is restricted making it independent of the viewport (otherwise users with different viewports would have different restriction for which coordinate positions [representing the viewport center] they can reach). I guess I could have alternatively set `.translateExtent` dynamically but I doubt that this would have been a nicer solution.

Now I have no idea whether this would be worth allowing in d3.zoom and if yes then how; maybe  `constrain()` could be made replaceable altough this would mean four additional parameters. So this is why this here is not a serious PR (and again please feel free to close it) and I would just like to have some  input.

(On a side node, in my project I tried using separate transforms for d3.zoom and the centering stuff, see <https://stackoverflow.com/q/46533546/2261442>, but in the end I wasn't able to come up with a useful solution, my own answer which I accepted also has severe drawbacks)