### PR TITLE
Touchmove should trigger filter method

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -332,6 +332,7 @@ export default function() {
   }
 
   function touchmoved() {
+    if (!filter.apply(this, arguments)) return;
     var g = gesture(this, arguments),
         touches = event.changedTouches,
         n = touches.length, i, t, p, l;


### PR DESCRIPTION
Similarly to touchstarted we want to have the ability to apply a filter to touchmove events. This way we can programmatically allow developers to filter touchmove events instead of allowing all. This implementation is similar to touchstarted. This resolves #124.