### PR TITLE
Fix doubletap on Chrome on Android

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -332,12 +332,14 @@ export default function() {
   }
 
   function touchmoved() {
+    if (touchstarting) return;
+
     var g = gesture(this, arguments),
         touches = event.changedTouches,
         n = touches.length, i, t, p, l;
 
     noevent();
-    if (touchstarting) return;
+
     for (i = 0; i < n; ++i) {
       t = touches[i], p = touch(this, touches, t.identifier);
       if (g.touch0 && g.touch0[2] === t.identifier) g.touch0[0] = p;

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -63,7 +63,7 @@ export default function() {
       listeners = dispatch("start", "zoom", "end"),
       touchstarting,
       touchending,
-      touchDelay = 500,
+      touchDelay = 250,
       wheelDelay = 150,
       clickDistance2 = 0;
 

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -337,7 +337,7 @@ export default function() {
         n = touches.length, i, t, p, l;
 
     noevent();
-    if (touchstarting) touchstarting = clearTimeout(touchstarting);
+    if (touchstarting) return;
     for (i = 0; i < n; ++i) {
       t = touches[i], p = touch(this, touches, t.identifier);
       if (g.touch0 && g.touch0[2] === t.identifier) g.touch0[0] = p;


### PR DESCRIPTION
Hi there, 

Thanks for this wonderful library!

I think I came across an unexpected behavior when testing it with latest Chrome 64.0.3282.137 on Google Pixel 2 XL, when a single tap generated one `touchstart` event, followed with upto 3 `touchmove` events.

I've tested this on iPhone 6s as well and only a single `touchstart` event was generated by a similar tap.

In order to make doubletap zoom work on Pixel, I had to prevent `touchmove` events from being triggered while `touchstarting` was `true`, and consequently decrease `touchDelay` to `250` to make touch panning less delayed.

This isn't a great solution since the value of `touchDelay` now essentially represents a compromise between the lag when panning starts and the permitted length of double-tap.

Unfortunately, with this sort of behavior occurring with the new Chrome on Android, I haven't thought of a better solution.

Thanks again!