### PR TITLE
Normalize defaultWheelDelta

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -31,7 +31,14 @@ function defaultTransform() {
 }
 
 function defaultWheelDelta() {
-  return -event.deltaY * (event.deltaMode ? 120 : 1) / 500;
+    var delta = (event.wheelDeltaY!==undefined ? event.wheelDeltaY : -event.deltaY);
+    if (event.deltaMode===0) {
+        return delta / 500;
+    } else if (event.deltaMode===1) {
+        return delta * 40 / 500;
+    } else { // event.deltaMode===2
+        return delta * 800 / 500;
+    }
 }
 
 function defaultTouchable() {


### PR DESCRIPTION
Normalized defaultWheelDelta so that it returns the same scaling speed in Chrome/FF/Edge. IE is still slightly different. Works with all three `deltaModes` (`0` => Pixel, `1` => Lines , `2` => Pages). Also uses `event.wheelDeltaY` when possible (Chrome and Edge), because it returns the same value on both browsers, while `event.deltaY` varies widely.

Related: https://github.com/d3/d3-zoom/pull/100