### PR TITLE
Use touches rather than changedTouches in touchstarted

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -301,7 +301,7 @@ export default function() {
   function touchstarted() {
     if (!filter.apply(this, arguments)) return;
     var g = gesture(this, arguments),
-        touches = event.changedTouches,
+        touches = event.touches,
         started,
         n = touches.length, i, t, p;
 


### PR DESCRIPTION
It seems that the behaviour of Chrome on Android differs from the behaviour of Safari on iOS in the following respect: when a multitouch event is initiated by touching two or more fingers to the screen near-simultaneously, iOS Safari will fire a single touchstart event that includes all the touches (as both event.touches and event.changedTouches) whereas Android Chrome will fire a sequence of touchstart events:

- one with `touches.length == 1` and `changedTouches.length == 1`
- followed by one with `touches.length == 2` and `changedTouches.length == 1`

In other words, the behaviour on Android Chrome when the screen is touched with two fingers simultaneously is the same as the behaviour on iOS Safari when you touch it first with one finger and then a second.

The change in PR #169 makes it possible to ignore single-touch gestures on iOS Safari, by returning a falsy value from the filter function when there is only a single touch, but this fails on Android Chrome because the first touch of a multitouch gesture is never recorded by d3-zoom: when the second touch is processed, the changedTouches array contains only the second touch.

This PR changes the behaviour of the touchstarted handler to consider all the touches in the event, rather than just the new touches, which appears to resolve the problem.