### PR TITLE
Fixing google's annoying passive listener warning.

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -72,7 +72,7 @@ export default function() {
   function zoom(selection) {
     selection
         .property("__zoom", defaultTransform)
-        .on("wheel.zoom", wheeled)
+        .on("wheel.zoom", wheeled, {passive: false})
         .on("mousedown.zoom", mousedowned)
         .on("dblclick.zoom", dblclicked)
       .filter(touchable)


### PR DESCRIPTION
This PR is in response to https://github.com/d3/d3-zoom/issues/103 and is primarily aimed to resolve this warning: 

![image](https://user-images.githubusercontent.com/21202515/97896338-ca2f7e80-1ce9-11eb-949f-594fa53c6523.png)

The intended behavior is for the zoom event to block scrolling so we just need to mark it as such. 
