### PR TITLE
Docs: Update default value for zoom.filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If *filter* is specified, sets the filter to the specified function and returns 
 
 ```js
 function filter(event) {
-  return !event.ctrlKey && !event.button;
+  return (!event.ctrlKey || event.type === 'wheel') && !event.button;
 }
 ```
 


### PR DESCRIPTION
Commit ab4bc6481d3a0e58cd727bad57ee684b98e8e26b changed the default value for `zoom.filter`. The change was not reflected in the documentation. This PR resolves that.