### PR TITLE
should be optional baseVal property

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -22,7 +22,7 @@ function defaultExtent() {
       e = e.viewBox.baseVal;
       return [[e.x, e.y], [e.x + e.width, e.y + e.height]];
     }
-    return [[0, 0], [e.width.baseVal.value, e.height.baseVal.value]];
+    return [[0, 0], [e.width?.baseVal.value, e.height?.baseVal.value]];
   }
   return [[0, 0], [e.clientWidth, e.clientHeight]];
 }


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'baseVal')

Getting above error while rendering the library in unit test cases using Jest environment. 

Also raised earlier by others as well: 
https://github.com/zcreativelabs/react-simple-maps/issues/245