### PR TITLE
Pin d3-selection dep to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "d3-dispatch": "1 - 3",
     "d3-drag": "2 - 3",
     "d3-interpolate": "1 - 3",
-    "d3-selection": "2 - 3",
+    "d3-selection": "3",
     "d3-transition": "2 - 3"
   },
   "devDependencies": {


### PR DESCRIPTION
zoom.transform uses selection.interrupt

~which conflicts if not using d3-selection 3.0.0 onwards~

which may conflict with different versions of d3-selection installed